### PR TITLE
better typescript types for monads

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: 'npm'
-    directory: '/'
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
-      interval: 'weekly'
+      interval: "weekly"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['18.x', '20.x']
+        node-version: ["18.x", "20.x"]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
+          cache: "pnpm"
       - run: pnpm install
       - run: pnpm format
       - run: pnpm lint

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,8 +16,8 @@ jobs:
       - name: Use Node.js 20.x
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
-          cache: 'pnpm'
+          node-version: "20.x"
+          cache: "pnpm"
       - run: pnpm install
       - run: pnpm run docs
       - name: Deploy to GitHub Pages

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,9 +17,9 @@ jobs:
       - name: Use Node.js 20.x
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
-          cache: 'pnpm'
+          node-version: "20.x"
+          registry-url: "https://registry.npmjs.org"
+          cache: "pnpm"
       - run: pnpm install
       - run: pnpm run build
       - run: pnpm publish --no-git-checks --access public

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Option represents an optional value: every Option is either Some and contains a 
 > Full documentation here: [Option](https://thames-technology.github.io/monads/interfaces/Option.html)
 
 ```ts
-import { Option, Some, None } from '@thames/monads';
+import { Option, Some, None } from "@thames/monads";
 
 const divide = (numerator: number, denominator: number): Option<number> => {
   if (denominator === 0) {
@@ -54,7 +54,7 @@ const result = divide(2.0, 3.0);
 // Pattern match to retrieve the value
 const message = result.match({
   some: (res) => `Result: ${res}`,
-  none: 'Cannot divide by 0',
+  none: "Cannot divide by 0",
 });
 
 console.log(message); // "Result: 0.6666666666666666"
@@ -68,23 +68,23 @@ Result represents a value that is either a success (Ok) or a failure (Err).
 > Full documentation here: [Result](https://thames-technology.github.io/monads/interfaces/Result.html)
 
 ```ts
-import { Result, Ok, Err } from '@thames/monads';
+import { Result, Ok, Err } from "@thames/monads";
 
 const getIndex = (values: string[], value: string): Result<number, string> => {
   const index = values.indexOf(value);
 
   switch (index) {
     case -1:
-      return Err('Value not found');
+      return Err("Value not found");
     default:
       return Ok(index);
   }
 };
 
-const values = ['a', 'b', 'c'];
+const values = ["a", "b", "c"];
 
-getIndex(values, 'b'); // Ok(1)
-getIndex(values, 'z'); // Err("Value not found")
+getIndex(values, "b"); // Ok(1)
+getIndex(values, "z"); // Err("Value not found")
 ```
 
 ### The `Either<L, R>` type
@@ -95,11 +95,14 @@ Either represents a value that is either Left or Right. It is a powerful way to 
 > Full documentation here: [Either](https://thames-technology.github.io/monads/interfaces/Either.html)
 
 ```ts
-import { Either, Left, Right } from '@thames/monads';
+import { Either, Left, Right } from "@thames/monads";
 
-const divide = (numerator: number, denominator: number): Either<string, number> => {
+const divide = (
+  numerator: number,
+  denominator: number
+): Either<string, number> => {
   if (denominator === 0) {
-    return Left('Cannot divide by 0');
+    return Left("Cannot divide by 0");
   } else {
     return Right(numerator / denominator);
   }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '@thames/eslint-config';
+export { default } from "@thames/eslint-config";

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,5 +1,5 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 export default {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
+  preset: "ts-jest",
+  testEnvironment: "node",
 };

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -1,1 +1,1 @@
-export { default } from '@thames/prettier-config';
+export { default } from "@thames/prettier-config";

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,24 +1,24 @@
-import { nodeResolve } from '@rollup/plugin-node-resolve';
-import typescript from '@rollup/plugin-typescript';
+import { nodeResolve } from "@rollup/plugin-node-resolve";
+import typescript from "@rollup/plugin-typescript";
 
 export default [
   {
-    input: 'src/index.ts',
+    input: "src/index.ts",
     output: [
       {
-        file: 'dist/index.cjs.js',
-        format: 'cjs',
+        file: "dist/index.cjs.js",
+        format: "cjs",
       },
       {
-        file: 'dist/index.esm.js',
-        format: 'esm',
+        file: "dist/index.esm.js",
+        format: "esm",
       },
     ],
     plugins: [
       nodeResolve(),
       typescript({
-        tsconfig: './tsconfig.json',
-        compilerOptions: { module: 'es2022', moduleResolution: 'bundler' },
+        tsconfig: "./tsconfig.json",
+        compilerOptions: { module: "es2022", moduleResolution: "bundler" },
       }),
     ],
   },

--- a/src/either/README.md
+++ b/src/either/README.md
@@ -3,7 +3,7 @@
 The `Either` type is symmetric and treats its variants the same way, without preference. For representing success or error, use [`Result<T, E>`](../result) instead.
 
 ```typescript
-import { Either } from '@sniptt/monads';
+import { Either } from "@sniptt/monads";
 
 const getLabel = (uncertainDate: Either<Date, string>): string => {
   return uncertainDate.match({

--- a/src/either/either.spec.ts
+++ b/src/either/either.spec.ts
@@ -1,51 +1,60 @@
-import { EitherType, isLeft, isRight, Left, Right } from './either';
+import {
+  Either,
+  EitherType,
+  isLeft,
+  isRight,
+  Left,
+  LeftEither,
+  Right,
+  RightEither,
+} from "./either";
 
-describe('Either', () => {
-  describe('Left', () => {
-    const error = 'error';
+describe("Either", () => {
+  describe("Left", () => {
+    const error = "error";
     const leftResult = Left<string, string>(error);
 
-    test('type should return Left', () => {
+    test("type should return Left", () => {
       expect(leftResult.type).toBe(EitherType.Left);
     });
 
-    test('isLeft should return true', () => {
+    test("isLeft should return true", () => {
       expect(leftResult.isLeft()).toBe(true);
     });
 
-    test('isRight should return false', () => {
+    test("isRight should return false", () => {
       expect(leftResult.isRight()).toBe(false);
     });
 
-    test('left should return a Some with the error', () => {
+    test("left should return a Some with the error", () => {
       expect(leftResult.left().unwrap()).toBe(error);
     });
 
-    test('right should return None', () => {
+    test("right should return None", () => {
       expect(leftResult.right().isNone()).toBe(true);
     });
 
-    test('unwrap should return the error', () => {
+    test("unwrap should return the error", () => {
       expect(leftResult.unwrap()).toBe(error);
     });
 
-    test('unwrapLeft should return the error', () => {
+    test("unwrapLeft should return the error", () => {
       expect(leftResult.unwrapLeft()).toBe(error);
     });
 
-    test('unwrapLeftOr should return the error', () => {
-      expect(leftResult.unwrapLeftOr('default')).toBe(error);
+    test("unwrapLeftOr should return the error", () => {
+      expect(leftResult.unwrapLeftOr("default")).toBe(error);
     });
 
-    test('unwrapRight should throw', () => {
+    test("unwrapRight should throw", () => {
       expect(() => leftResult.unwrapRight()).toThrow();
     });
 
-    test('unwrapRightOr should return the default value', () => {
-      expect(leftResult.unwrapRightOr('default')).toBe('default');
+    test("unwrapRightOr should return the default value", () => {
+      expect(leftResult.unwrapRightOr("default")).toBe("default");
     });
 
-    test('match should execute left branch', () => {
+    test("match should execute left branch", () => {
       const result = leftResult.match({
         left: (val) => `Left ${val}`,
         right: (val) => `Right ${val}`,
@@ -53,72 +62,74 @@ describe('Either', () => {
       expect(result).toBe(`Left ${error}`);
     });
 
-    test('mapLeft should return a new Left with the mapped value', () => {
+    test("mapLeft should return a new Left with the mapped value", () => {
       const mapped = leftResult.mapLeft((val) => val.toUpperCase());
       expect(mapped.left().unwrap()).toBe(error.toUpperCase());
     });
 
-    test('mapRight should not apply function and return Left', () => {
+    test("mapRight should not apply function and return Left", () => {
       const mapped = leftResult.mapRight((val) => val.length);
       expect(mapped).toStrictEqual(leftResult);
     });
 
-    test('leftAndThen should return a new Left with the mapped value', () => {
-      const andThenResult = leftResult.leftAndThen((val) => Left(val.toUpperCase()));
+    test("leftAndThen should return a new Left with the mapped value", () => {
+      const andThenResult = leftResult.leftAndThen((val) =>
+        Left(val.toUpperCase())
+      );
       expect(andThenResult.left().unwrap()).toBe(error.toUpperCase());
     });
 
-    test('rightAndThen should not apply function and return Left', () => {
+    test("rightAndThen should not apply function and return Left", () => {
       const andThenResult = leftResult.rightAndThen((val) => Right(val.length));
       expect(andThenResult).toStrictEqual(leftResult);
     });
   });
 
-  describe('Right', () => {
-    const value = 'success';
+  describe("Right", () => {
+    const value = "success";
     const rightResult = Right<string, string>(value);
 
-    test('type should return Right', () => {
+    test("type should return Right", () => {
       expect(rightResult.type).toBe(EitherType.Right);
     });
 
-    test('isLeft should return false', () => {
+    test("isLeft should return false", () => {
       expect(rightResult.isLeft()).toBe(false);
     });
 
-    test('isRight should return true', () => {
+    test("isRight should return true", () => {
       expect(rightResult.isRight()).toBe(true);
     });
 
-    test('left should return None', () => {
+    test("left should return None", () => {
       expect(rightResult.left().isNone()).toBe(true);
     });
 
-    test('right should return a Some with the value', () => {
+    test("right should return a Some with the value", () => {
       expect(rightResult.right().unwrap()).toBe(value);
     });
 
-    test('unwrap should return the value', () => {
+    test("unwrap should return the value", () => {
       expect(rightResult.unwrap()).toBe(value);
     });
 
-    test('unwrapLeft should throw', () => {
+    test("unwrapLeft should throw", () => {
       expect(() => rightResult.unwrapLeft()).toThrow();
     });
 
-    test('unwrapLeftOr should return the default value', () => {
-      expect(rightResult.unwrapLeftOr('default')).toBe('default');
+    test("unwrapLeftOr should return the default value", () => {
+      expect(rightResult.unwrapLeftOr("default")).toBe("default");
     });
 
-    test('unwrapRight should return the value', () => {
+    test("unwrapRight should return the value", () => {
       expect(rightResult.unwrapRight()).toBe(value);
     });
 
-    test('unwrapRightOr should return the value', () => {
-      expect(rightResult.unwrapRightOr('default')).toBe(value);
+    test("unwrapRightOr should return the value", () => {
+      expect(rightResult.unwrapRightOr("default")).toBe(value);
     });
 
-    test('match should execute right branch', () => {
+    test("match should execute right branch", () => {
       const result = rightResult.match({
         left: (val) => `Left ${val}`,
         right: (val) => `Right ${val}`,
@@ -126,50 +137,94 @@ describe('Either', () => {
       expect(result).toBe(`Right ${value}`);
     });
 
-    test('mapLeft should not apply function and return Right', () => {
+    test("mapLeft should not apply function and return Right", () => {
       const mapped = rightResult.mapLeft((val) => val.toUpperCase());
       expect(mapped).toStrictEqual(rightResult);
     });
 
-    test('mapRight should return a new Right with the mapped value', () => {
+    test("mapRight should return a new Right with the mapped value", () => {
       const mapped = rightResult.mapRight((val) => val.length);
       expect(mapped.right().unwrap()).toBe(value.length);
     });
 
-    test('leftAndThen should not apply function and return Right', () => {
-      const andThenResult = rightResult.leftAndThen((val) => Left(val.toUpperCase()));
+    test("leftAndThen should not apply function and return Right", () => {
+      const andThenResult = rightResult.leftAndThen((val) =>
+        Left(val.toUpperCase())
+      );
       expect(andThenResult).toStrictEqual(rightResult);
     });
 
-    test('rightAndThen should return a new Right with the mapped value', () => {
-      const andThenResult = rightResult.rightAndThen((val) => Right(val.length));
+    test("rightAndThen should return a new Right with the mapped value", () => {
+      const andThenResult = rightResult.rightAndThen((val) =>
+        Right(val.length)
+      );
       expect(andThenResult.right().unwrap()).toBe(value.length);
     });
   });
 
-  describe('isLeft', () => {
-    const left = Left('error');
-    const right = Right('success');
+  describe("isLeft", () => {
+    const left = Left("error");
+    const right = Right("success");
 
-    test('should return true for Left', () => {
+    test("should return true for Left", () => {
       expect(isLeft(left)).toBe(true);
     });
 
-    test('should return false for Right', () => {
+    test("should return false for Right", () => {
       expect(isLeft(right)).toBe(false);
     });
   });
 
-  describe('isRight', () => {
-    const left = Left('error');
-    const right = Right('success');
+  describe("isRight", () => {
+    const left = Left("error");
+    const right = Right("success");
 
-    test('should return false for Left', () => {
+    test("should return false for Left", () => {
       expect(isRight(left)).toBe(false);
     });
 
-    test('should return true for Right', () => {
+    test("should return true for Right", () => {
       expect(isRight(right)).toBe(true);
+    });
+  });
+
+  describe("typeguards", () => {
+    const l = "left" as const;
+    const r = "right" as const;
+    type NonUndefined = {} | null; // eslint-disable-line @typescript-eslint/ban-types
+
+    type Expect<T extends true> = T;
+    type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <
+      T
+    >() => T extends Y ? 1 : 2
+      ? true
+      : false;
+    type ExpectNever<T> = Equal<T, never>;
+
+    test("isLeft and isRight should serve as typeguards", () => {
+      const l1 = Left(l);
+      type LT1 = Expect<Equal<typeof l1, LeftEither<"left", never>>>;
+      const l2 = l1.mapLeft((x) => "updated" as const);
+      type LT2 = Expect<Equal<typeof l2, LeftEither<"updated", never>>>;
+      const l3 = l1.mapRight((x) => "not relevant" as const);
+      type LT3 = Expect<Equal<typeof l3, LeftEither<"left", "not relevant">>>;
+
+      const left = l1.left().unwrap();
+      type LT4 = Expect<Equal<typeof left, "left">>;
+      const right = l1.right().unwrap();
+      type LT5 = Expect<ExpectNever<typeof right>>;
+
+      const r1 = Right(r);
+      type RT1 = Expect<Equal<typeof r1, RightEither<never, "right">>>;
+      const r2 = r1.mapLeft((x) => "not relevant" as const);
+      type RT2 = Expect<Equal<typeof r2, RightEither<"not relevant", "right">>>;
+      const r3 = r1.mapRight((x) => "updated" as const);
+      type RT3 = Expect<Equal<typeof r3, RightEither<never, "updated">>>;
+
+      const left2 = r1.left().unwrap();
+      type RT4 = Expect<ExpectNever<typeof left2>>;
+      const right2 = r1.right().unwrap();
+      type RT5 = Expect<Equal<typeof right2, "right">>;
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export * from './either/either';
-export * from './option/option';
-export * from './result/result';
+export * from "./either/either";
+export * from "./option/option";
+export * from "./result/result";

--- a/src/option/README.md
+++ b/src/option/README.md
@@ -10,7 +10,7 @@ You could consider using `Option` for:
 `Option`s are commonly paired with pattern matching to query the presence of a value and take action, always accounting for the `None` case.
 
 ```typescript
-import { Option, Some, None } from '@sniptt/monads';
+import { Option, Some, None } from "@sniptt/monads";
 
 function divide(numerator: number, denominator: number): Option<number> {
   if (denominator === 0) {
@@ -26,7 +26,7 @@ const result = divide(2.0, 3.0);
 // Pattern match to retrieve the value
 const message = result.match({
   some: (res) => `Result: ${res}`,
-  none: 'Cannot divide by 0',
+  none: "Cannot divide by 0",
 });
 
 console.log(message); // "Result: 0.6666666666666666"

--- a/src/option/option.spec.ts
+++ b/src/option/option.spec.ts
@@ -1,132 +1,162 @@
-import { isNone, isSome, None, Option, OptionType, Some } from './option';
+import { isNone, isSome, None, Option, OptionType, Some } from "./option";
 
-describe('Option', () => {
-  describe('Some', () => {
-    const value = 'test';
+describe("Option", () => {
+  describe("Some", () => {
+    const value = "test";
     const someOption: Option<string> = Some(value);
 
-    test('type should return Some', () => {
+    test("type should return Some", () => {
       expect(someOption.type).toBe(OptionType.Some);
     });
 
-    test('isSome should return true', () => {
+    test("isSome should return true", () => {
       expect(someOption.isSome()).toBe(true);
     });
 
-    test('isNone should return false', () => {
+    test("isNone should return false", () => {
       expect(someOption.isNone()).toBe(false);
     });
 
-    test('match should execute some branch', () => {
+    test("match should execute some branch", () => {
       const result = someOption.match({
         some: (val) => `Some ${val}`,
-        none: 'None',
+        none: "None",
       });
       expect(result).toBe(`Some ${value}`);
     });
 
-    test('map should apply function and wrap result in Some', () => {
+    test("map should apply function and wrap result in Some", () => {
       const mapped = someOption.map((val) => val.length);
       expect(mapped.unwrap()).toBe(value.length);
     });
 
-    test('andThen should apply function returning Option', () => {
+    test("andThen should apply function returning Option", () => {
       const andThenResult = someOption.andThen((val) => Some(val.length));
       expect(andThenResult.unwrap()).toBe(value.length);
     });
 
-    test('or should return original Some if not None', () => {
-      const orResult = someOption.or(Some('other'));
+    test("or should return original Some if not None", () => {
+      const orResult = someOption.or(Some("other"));
       expect(orResult.unwrap()).toBe(value);
     });
 
-    test('and should return passed Option if original is Some', () => {
-      const andResult = someOption.and(Some('other'));
-      expect(andResult.unwrap()).toBe('other');
+    test("and should return passed Option if original is Some", () => {
+      const andResult = someOption.and(Some("other"));
+      expect(andResult.unwrap()).toBe("other");
     });
 
-    test('unwrapOr should return value', () => {
-      expect(someOption.unwrapOr('default')).toBe(value);
+    test("unwrapOr should return value", () => {
+      expect(someOption.unwrapOr("default")).toBe(value);
     });
 
-    test('unwrap should return value', () => {
+    test("unwrap should return value", () => {
       expect(someOption.unwrap()).toBe(value);
     });
   });
 
-  describe('None', () => {
-    test('type should return None', () => {
+  describe("None", () => {
+    test("type should return None", () => {
       expect(None.type).toBe(OptionType.None);
     });
 
-    test('isSome should return false', () => {
+    test("isSome should return false", () => {
       expect(None.isSome()).toBe(false);
     });
 
-    test('isNone should return true', () => {
+    test("isNone should return true", () => {
       expect(None.isNone()).toBe(true);
     });
 
-    test('match should execute none branch', () => {
+    test("match should execute none branch", () => {
       const result = None.match({
         some: (val) => `Some ${val}`,
-        none: () => 'None',
+        none: () => "None",
       });
-      expect(result).toBe('None');
+      expect(result).toBe("None");
     });
 
-    test('map should not apply function and return None', () => {
+    test("map should not apply function and return None", () => {
       const mapped = None.map((val: string) => val.length);
       expect(mapped).toStrictEqual(None);
     });
 
-    test('andThen should not apply function and return None', () => {
+    test("andThen should not apply function and return None", () => {
       const andThenResult = None.andThen((val: string) => Some(val.length));
       expect(andThenResult).toStrictEqual(None);
     });
 
-    test('or should return passed Option if original is None', () => {
-      const orResult = None.or(Some('other'));
-      expect(orResult.unwrap()).toBe('other');
+    test("or should return passed Option if original is None", () => {
+      const orResult = None.or(Some("other"));
+      expect(orResult.unwrap()).toBe("other");
     });
 
-    test('and should return None if original is None', () => {
-      const andResult = None.and(Some('other'));
+    test("and should return None if original is None", () => {
+      const andResult = None.and(Some("other"));
       expect(andResult).toStrictEqual(None);
     });
 
-    test('unwrapOr should return default value', () => {
-      expect(None.unwrapOr('default')).toBe('default');
+    test("unwrapOr should return default value", () => {
+      expect(None.unwrapOr("default")).toBe("default");
     });
 
-    test('unwrap should throw', () => {
+    test("unwrap should throw", () => {
       expect(() => None.unwrap()).toThrow();
     });
   });
 
-  describe('isSome', () => {
-    const some = Some('test');
+  describe("isSome", () => {
+    const some = Some("test");
     const none = None;
 
-    test('should return true for Some', () => {
+    test("should return true for Some", () => {
       expect(isSome(some)).toBe(true);
     });
 
-    test('should return false for None', () => {
+    test("should return false for None", () => {
       expect(isSome(none)).toBe(false);
     });
   });
 
-  describe('isNone', () => {
-    const some = Some('test');
+  describe("isNone", () => {
+    const some = Some("test");
     const none = None;
 
-    test('should return false for Some', () => {
+    test("should return false for Some", () => {
       expect(isNone(some)).toBe(false);
     });
 
-    test('should return true for None', () => {
+    test("should return true for None", () => {
       expect(isNone(none)).toBe(true);
+    });
+  });
+
+  describe("typeguards", () => {
+    const value = "success" as const;
+    const result: Option<typeof value> = Some(value);
+    type NonUndefined = {} | null; // eslint-disable-line @typescript-eslint/ban-types
+
+    type Expect<T extends true> = T;
+    type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <
+      T
+    >() => T extends Y ? 1 : 2
+      ? true
+      : false;
+
+    test("isSome and isNone should serve as typeguards", () => {
+      if (result.isSome()) {
+        const x = result.unwrap();
+        type T = Expect<Equal<typeof x, typeof value>>; // this will only typecheck if typeof x is the same as typeof value
+      }
+      if (result.isNone()) {
+        const x = result.unwrap();
+        type T = Expect<Equal<typeof x, never>>; // this will only typecheck if typeof x is never
+      }
+    });
+    test("typeguardds should continue even with mapping", () => {
+      if (result.isSome()) {
+        const x = result.map((v) => "Invoked!" as const).unwrap();
+        type T = Expect<Equal<typeof x, "Invoked!">>;
+      }
     });
   });
 });

--- a/src/result/README.md
+++ b/src/result/README.md
@@ -5,21 +5,21 @@ You could consider using `Result` for:
 - Return value whenever errors are expected and recoverable
 
 ```typescript
-import { Result, Ok, Err } from '@sniptt/monads';
+import { Result, Ok, Err } from "@sniptt/monads";
 
 function getIndex(values: string[], value: string): Result<number, string> {
   const index = values.indexOf(value);
 
   switch (index) {
     case -1:
-      return Err('Value not found');
+      return Err("Value not found");
     default:
       return Ok(index);
   }
 }
 
-console.log(getIndex(['a', 'b', 'c'], 'b')); // Ok(1)
-console.log(getIndex(['a', 'b', 'c'], 'z')); // Err("Value not found")
+console.log(getIndex(["a", "b", "c"], "b")); // Ok(1)
+console.log(getIndex(["a", "b", "c"], "z")); // Err("Value not found")
 ```
 
 Original implementation: <https://doc.rust-lang.org/std/result/enum.Result.html>

--- a/src/result/result.spec.ts
+++ b/src/result/result.spec.ts
@@ -1,43 +1,43 @@
-import { Err, isErr, isOk, Ok, Result, ResultType } from './result';
+import { Err, isErr, isOk, Ok, Result, ResultType } from "./result";
 
-describe('Result', () => {
-  describe('Ok', () => {
-    const value = 'success';
+describe("Result", () => {
+  describe("Ok", () => {
+    const value = "success";
     const okResult: Result<string, string> = Ok(value);
 
-    test('type should return Ok', () => {
+    test("type should return Ok", () => {
       expect(okResult.type).toBe(ResultType.Ok);
     });
 
-    test('isOk should return true', () => {
+    test("isOk should return true", () => {
       expect(okResult.isOk()).toBe(true);
     });
 
-    test('isErr should return false', () => {
+    test("isErr should return false", () => {
       expect(okResult.isErr()).toBe(false);
     });
 
-    test('ok should return a Some with the value', () => {
+    test("ok should return a Some with the value", () => {
       expect(okResult.ok().unwrap()).toBe(value);
     });
 
-    test('err should return None', () => {
+    test("err should return None", () => {
       expect(okResult.err().isNone()).toBe(true);
     });
 
-    test('unwrap should return the value', () => {
+    test("unwrap should return the value", () => {
       expect(okResult.unwrap()).toBe(value);
     });
 
-    test('unwrapErr should throw', () => {
+    test("unwrapErr should throw", () => {
       expect(() => okResult.unwrapErr()).toThrow();
     });
 
-    test('unwrapOr should return the value', () => {
-      expect(okResult.unwrapOr('default')).toBe(value);
+    test("unwrapOr should return the value", () => {
+      expect(okResult.unwrapOr("default")).toBe(value);
     });
 
-    test('match should execute ok branch', () => {
+    test("match should execute ok branch", () => {
       const result = okResult.match({
         ok: (val) => `Ok ${val}`,
         err: (val) => `Err ${val}`,
@@ -45,64 +45,64 @@ describe('Result', () => {
       expect(result).toBe(`Ok ${value}`);
     });
 
-    test('map should apply function and wrap result in Ok', () => {
+    test("map should apply function and wrap result in Ok", () => {
       const mapped = okResult.map((val) => val.length);
       expect(mapped.unwrap()).toBe(value.length);
     });
 
-    test('mapErr should not apply function and return Ok', () => {
+    test("mapErr should not apply function and return Ok", () => {
       const mappedErr = okResult.mapErr((err) => `Error: ${err}`);
       expect(mappedErr.unwrap()).toBe(value);
     });
 
-    test('andThen should apply function returning Result', () => {
+    test("andThen should apply function returning Result", () => {
       const andThenResult = okResult.andThen((val) => Ok(val.length));
       expect(andThenResult.unwrap()).toBe(value.length);
     });
 
-    test('orElse should not apply function and return Ok', () => {
+    test("orElse should not apply function and return Ok", () => {
       const orElseResult = okResult.orElse((err) => Err(`Error: ${err}`));
       expect(orElseResult.unwrap()).toBe(value);
     });
   });
 
-  describe('Err', () => {
-    const error = 'error';
+  describe("Err", () => {
+    const error = "error";
     const errResult: Result<string, string> = Err(error);
 
-    test('type should return Err', () => {
+    test("type should return Err", () => {
       expect(errResult.type).toBe(ResultType.Err);
     });
 
-    test('isOk should return false', () => {
+    test("isOk should return false", () => {
       expect(errResult.isOk()).toBe(false);
     });
 
-    test('isErr should return true', () => {
+    test("isErr should return true", () => {
       expect(errResult.isErr()).toBe(true);
     });
 
-    test('ok should return None', () => {
+    test("ok should return None", () => {
       expect(errResult.ok().isNone()).toBe(true);
     });
 
-    test('err should return a Some with the error', () => {
+    test("err should return a Some with the error", () => {
       expect(errResult.err().unwrap()).toBe(error);
     });
 
-    test('unwrap should throw', () => {
+    test("unwrap should throw", () => {
       expect(() => errResult.unwrap()).toThrow();
     });
 
-    test('unwrapErr should return the error', () => {
+    test("unwrapErr should return the error", () => {
       expect(errResult.unwrapErr()).toBe(error);
     });
 
-    test('unwrapOr should return the default value', () => {
-      expect(errResult.unwrapOr('default')).toBe('default');
+    test("unwrapOr should return the default value", () => {
+      expect(errResult.unwrapOr("default")).toBe("default");
     });
 
-    test('match should execute err branch', () => {
+    test("match should execute err branch", () => {
       const result = errResult.match({
         ok: (val) => `Ok ${val}`,
         err: (val) => `Err ${val}`,
@@ -110,50 +110,99 @@ describe('Result', () => {
       expect(result).toBe(`Err ${error}`);
     });
 
-    test('map should not apply function and return Err', () => {
+    test("map should not apply function and return Err", () => {
       const mapped = errResult.map((val) => val.length);
       expect(() => mapped.unwrap()).toThrow();
     });
 
-    test('mapErr should apply function and wrap result in Err', () => {
+    test("mapErr should apply function and wrap result in Err", () => {
       const mappedErr = errResult.mapErr((err) => `Error: ${err}`);
       expect(mappedErr.unwrapErr()).toBe(`Error: ${error}`);
     });
 
-    test('andThen should not apply function and return Err', () => {
+    test("andThen should not apply function and return Err", () => {
       const andThenResult = errResult.andThen((val) => Ok(val.length));
       expect(() => andThenResult.unwrap()).toThrow();
     });
 
-    test('orElse should apply function returning Result', () => {
-      const orElseResult = errResult.orElse((err) => Ok(`Recovered from ${err}`));
+    test("orElse should apply function returning Result", () => {
+      const orElseResult = errResult.orElse((err) =>
+        Ok(`Recovered from ${err}`)
+      );
       expect(orElseResult.unwrap()).toBe(`Recovered from ${error}`);
     });
   });
 
-  describe('isOk', () => {
-    const ok = Ok('success');
-    const err = Err('error');
+  describe("isOk", () => {
+    const ok = Ok("success");
+    const err = Err("error");
 
-    test('should return true for Ok', () => {
+    test("should return true for Ok", () => {
       expect(isOk(ok)).toBe(true);
     });
 
-    test('should return false for Err', () => {
+    test("should return false for Err", () => {
       expect(isOk(err)).toBe(false);
     });
   });
 
-  describe('isErr', () => {
-    const ok = Ok('success');
-    const err = Err('error');
+  describe("isErr", () => {
+    const ok = Ok("success");
+    const err = Err("error");
 
-    test('should return false for Ok', () => {
+    test("should return false for Ok", () => {
       expect(isErr(ok)).toBe(false);
     });
 
-    test('should return true for Err', () => {
+    test("should return true for Err", () => {
       expect(isErr(err)).toBe(true);
+    });
+  });
+
+  describe("typeguards", () => {
+    const value = "success";
+    const result: Result<string, string> = Ok(value);
+    // Will throw a type error if `arg` is not never
+    const assertNever = (arg: never): never => {
+      return arg;
+    };
+    test("isOk should serve as a typeguard", () => {
+      if (result.isOk()) {
+        assertNever(result.unwrapErr()); // is `never`, as expected
+        // @ts-expect-error - not `never`
+        assertNever(result.unwrap()); // is not `never`, as expected
+      }
+    });
+    test("isErr should serve as a typeguard", () => {
+      if (result.isErr()) {
+        assertNever(result.unwrap()); // is `never`, as expected
+        // @ts-expect-error - not `never`
+        assertNever(result.unwrapErr()); // is not `never`, as expected
+      }
+    });
+    test("typeguardds should continue even with mapping", () => {
+      if (result.isOk()) {
+        const updatedRes = result.map((v) => "Invoked!");
+        assertNever(updatedRes.err().unwrap());
+        // @ts-expect-error - not `never`
+        assertNever(updatedRes.ok().unwrap());
+
+        const updatedErr = result.mapErr((v) => new Error("Never invoked"));
+        assertNever(updatedErr.err().unwrap());
+        // @ts-expect-error - not `never`
+        assertNever(updatedErr.ok().unwrap());
+      }
+      if (result.isErr()) {
+        const updatedRes = result.map((v) => "Never invoked");
+        assertNever(updatedRes.ok().unwrap());
+        // @ts-expect-error - not `never`
+        assertNever(updatedRes.err().unwrap());
+
+        const updatedErr = result.mapErr((v) => new Error("Invoked!"));
+        assertNever(updatedErr.ok().unwrap());
+        // @ts-expect-error - not `never`
+        assertNever(updatedErr.err().unwrap());
+      }
     });
   });
 });

--- a/src/result/result.ts
+++ b/src/result/result.ts
@@ -1,4 +1,4 @@
-import { None, Option, Some } from '../option/option';
+import { None, NoneOption, Option, Some, SomeOption } from "../option/option";
 
 /**
  * Type representing any value except 'undefined'.
@@ -10,8 +10,8 @@ type NonUndefined = {} | null; // eslint-disable-line @typescript-eslint/ban-typ
  * Enum-like object to represent the type of a Result (Ok or Err).
  */
 export const ResultType = {
-  Ok: Symbol(':ok'),
-  Err: Symbol(':err'),
+  Ok: Symbol(":ok"),
+  Err: Symbol(":err"),
 };
 
 /**
@@ -45,7 +45,7 @@ export interface Result<T extends NonUndefined, E extends NonUndefined> {
    * console.log(Err("error").isOk()); // false
    * ```
    */
-  isOk(): boolean;
+  isOk(): this is OkResult<T, E>;
 
   /**
    * Checks if the Result is an Err.
@@ -59,7 +59,7 @@ export interface Result<T extends NonUndefined, E extends NonUndefined> {
    * console.log(Err("error").isErr()); // true
    * ```
    */
-  isErr(): boolean;
+  isErr(): this is ErrResult<T, E>;
 
   /**
    * Converts the Result to an Option containing the success value, or None if Err.
@@ -229,54 +229,66 @@ export interface Result<T extends NonUndefined, E extends NonUndefined> {
 /**
  * Implementation of Result representing a successful value (Ok).
  */
-interface OkResult<T extends NonUndefined, E extends NonUndefined> extends Result<T, E> {
+interface OkResult<T extends NonUndefined, E extends NonUndefined>
+  extends Result<T, E> {
+  ok(): SomeOption<T>;
+  err(): NoneOption<E>;
   unwrap: () => T;
   unwrapErr: () => never;
+  map<U extends NonUndefined>(fn: (val: T) => U): OkResult<U, E>;
+  mapErr<U extends NonUndefined>(fn: (err: E) => U): OkResult<T, U>;
 }
 
 /**
  * Implementation of Result representing an error value (Err).
  */
-interface ErrResult<T extends NonUndefined, E extends NonUndefined> extends Result<T, E> {
+interface ErrResult<T extends NonUndefined, E extends NonUndefined>
+  extends Result<T, E> {
+  ok(): NoneOption<T>;
+  err(): SomeOption<E>;
   unwrap: () => never;
   unwrapErr: () => E;
+  map<U extends NonUndefined>(fn: (val: T) => U): ErrResult<U, E>;
+  mapErr<U extends NonUndefined>(fn: (err: E) => U): ErrResult<T, U>;
 }
 
 /**
  * Represents a Ok Result.
  */
-class OkImpl<T extends NonUndefined, E extends NonUndefined> implements OkResult<T, E> {
+class OkImpl<T extends NonUndefined, E extends NonUndefined>
+  implements OkResult<T, E>
+{
   constructor(private readonly val: T) {}
 
   get type() {
     return ResultType.Ok;
   }
 
-  isOk() {
+  isOk(): this is OkResult<T, E> {
     return true;
   }
 
-  isErr() {
+  isErr(): this is ErrResult<T, E> {
     return false;
   }
 
-  ok(): Option<T> {
+  ok(): SomeOption<T> {
     return Some(this.val);
   }
 
-  err(): Option<E> {
-    return None;
+  err(): NoneOption<E> {
+    return None as NoneOption<E>;
   }
 
   match<U extends NonUndefined>(matchObject: Match<T, E, U>): U {
     return matchObject.ok(this.val);
   }
 
-  map<U extends NonUndefined>(fn: (val: T) => U): Result<U, E> {
-    return Ok(fn(this.val));
+  map<U extends NonUndefined>(fn: (val: T) => U): OkResult<U, E> {
+    return Ok<U, E>(fn(this.val));
   }
 
-  mapErr<U extends NonUndefined>(_fn: (err: E) => U): Result<T, U> {
+  mapErr<U extends NonUndefined>(_fn: (err: E) => U): OkResult<T, U> {
     return Ok(this.val);
   }
 
@@ -293,7 +305,7 @@ class OkImpl<T extends NonUndefined, E extends NonUndefined> implements OkResult
   }
 
   unwrapErr(): never {
-    throw new ReferenceError('Cannot unwrap Err value of Result.Ok');
+    throw new ReferenceError("Cannot unwrap Err value of Result.Ok");
   }
 
   unwrapOr(_optb: T): T {
@@ -304,26 +316,28 @@ class OkImpl<T extends NonUndefined, E extends NonUndefined> implements OkResult
 /**
  * Represents an Err Result.
  */
-class ErrImpl<T extends NonUndefined, E extends NonUndefined> implements ErrResult<T, E> {
+class ErrImpl<T extends NonUndefined, E extends NonUndefined>
+  implements ErrResult<T, E>
+{
   constructor(private readonly val: E) {}
 
   get type() {
     return ResultType.Err;
   }
 
-  isOk() {
+  isOk(): this is OkResult<T, E> {
     return false;
   }
 
-  isErr() {
+  isErr(): this is ErrResult<T, E> {
     return true;
   }
 
-  ok(): Option<T> {
-    return None;
+  ok(): NoneOption<T> {
+    return None as NoneOption<T>;
   }
 
-  err(): Option<E> {
+  err(): SomeOption<E> {
     return Some(this.val);
   }
 
@@ -331,11 +345,11 @@ class ErrImpl<T extends NonUndefined, E extends NonUndefined> implements ErrResu
     return matchObject.err(this.val);
   }
 
-  map<U extends NonUndefined>(_fn: (val: T) => U): Result<U, E> {
+  map<U extends NonUndefined>(_fn: (val: T) => U): ErrResult<U, E> {
     return Err(this.val);
   }
 
-  mapErr<U extends NonUndefined>(fn: (err: E) => U): Result<T, U> {
+  mapErr<U extends NonUndefined>(fn: (err: E) => U): ErrResult<T, U> {
     return Err(fn(this.val));
   }
 
@@ -348,7 +362,7 @@ class ErrImpl<T extends NonUndefined, E extends NonUndefined> implements ErrResu
   }
 
   unwrap(): never {
-    throw new ReferenceError('Cannot unwrap Ok value of Result.Err');
+    throw new ReferenceError("Cannot unwrap Ok value of Result.Err");
   }
 
   unwrapErr(): E {
@@ -374,7 +388,9 @@ class ErrImpl<T extends NonUndefined, E extends NonUndefined> implements ErrResu
  * console.log(successResult.unwrap()); // Outputs: 42
  * ```
  */
-export function Ok<T extends NonUndefined, E extends NonUndefined = never>(val: T): Result<T, E> {
+export function Ok<T extends NonUndefined, E extends NonUndefined = never>(
+  val: T
+): OkResult<T, E> {
   return new OkImpl(val);
 }
 
@@ -392,7 +408,9 @@ export function Ok<T extends NonUndefined, E extends NonUndefined = never>(val: 
  * console.log(errorResult.unwrapErr()); // Outputs: Something went wrong
  * ```
  */
-export function Err<T extends NonUndefined, E extends NonUndefined>(val: E): Result<T, E> {
+export function Err<T extends NonUndefined, E extends NonUndefined>(
+  val: E
+): ErrResult<T, E> {
   return new ErrImpl(val);
 }
 
@@ -413,7 +431,7 @@ export function Err<T extends NonUndefined, E extends NonUndefined>(val: E): Res
  * ```
  */
 export function isOk<T extends NonUndefined, E extends NonUndefined>(
-  val: Result<T, E>,
+  val: Result<T, E>
 ): val is OkResult<T, never> {
   return val.isOk();
 }
@@ -435,7 +453,7 @@ export function isOk<T extends NonUndefined, E extends NonUndefined>(
  * ```
  */
 export function isErr<T extends NonUndefined, E extends NonUndefined>(
-  val: Result<T, E>,
+  val: Result<T, E>
 ): val is ErrResult<never, E> {
   return val.isErr();
 }


### PR DESCRIPTION
Typescript type guards can be really powerful. When using monads, there's no risk of the state changing under the hood, so once we know the type of these monads we can carry them through even over transformations.

Take this simple case
```typescript
interface Success<T> { data: T }
interface Error<P> { message: string; payload: P }

function sometimesThisErrors(): Result<Success<MyData>, Error<MyPayload>> {}

const maybeThisWorked = sometimesThisErrors();
if (maybeThisWorked.isOk()) {
    const data = maybeThisWorked.unwrap().data;
} else {
    const payload = maybeThisWorked.unwrapErr().payload;
}
```

With the existing types, `data` is `T | undefined` and `payload` is `P | undefined`. But we know that `data` is actually `T`, thats the point of the `isOk()`!

We can follow this logic for `Option`, `Either` and `Result`. [One thing I didn't do in this PR is work on the fact that we know there are exactly 2 variants for each monad]

I did not update any runtime code.

Side note: I ran `prettier . --write` and it updated a ton of files.
