### PR TITLE
Add `expect`-like functionality to `Result` and `Option`

### DIFF
--- a/src/option/option.spec.ts
+++ b/src/option/option.spec.ts
@@ -102,6 +102,12 @@ describe('Option', () => {
     test('unwrap should throw', () => {
       expect(() => None.unwrap()).toThrow();
     });
+
+    test('unwrap may throw with custom message', () => {
+      const msg = 'whoopsie';
+      expect(() => None.unwrap(msg)).toThrow(msg);
+      expect(() => None.unwrap()).not.toThrow(msg);
+    });
   });
 
   describe('isSome', () => {

--- a/src/option/option.ts
+++ b/src/option/option.ts
@@ -183,21 +183,21 @@ export interface Option<T extends NonUndefined> {
    * console.log(None.unwrap()); // throws Error
    * ```
    */
-  unwrap(): T | never;
+  unwrap(msg?: string): T | never;
 }
 
 /**
  * Implementation of Option representing a value (Some).
  */
 interface SomeOption<T extends NonUndefined> extends Option<T> {
-  unwrap(): T;
+  unwrap(msg?: string): T;
 }
 
 /**
  * Implementation of Option representing the absence of a value (None).
  */
 interface NoneOption<T extends NonUndefined> extends Option<T> {
-  unwrap(): never;
+  unwrap(msg?: string): never;
 }
 
 /**
@@ -242,7 +242,7 @@ class SomeImpl<T extends NonUndefined> implements SomeOption<T> {
     return this.val;
   }
 
-  unwrap(): T {
+  unwrap(_msg?: string): T {
     return this.val;
   }
 }
@@ -291,8 +291,12 @@ class NoneImpl<T extends NonUndefined> implements NoneOption<T> {
     return def;
   }
 
-  unwrap(): never {
-    throw new ReferenceError('Trying to unwrap None.');
+  unwrap(msg?: string): never {
+    if (msg) {
+      throw new Error(msg);
+    } else {
+      throw new ReferenceError('Trying to unwrap None.');
+    }
   }
 }
 

--- a/src/result/result.spec.ts
+++ b/src/result/result.spec.ts
@@ -1,6 +1,8 @@
 import { Err, isErr, isOk, Ok, Result, ResultType } from './result';
 
 describe('Result', () => {
+  const errorMsg = 'whoopsie';
+
   describe('Ok', () => {
     const value = 'success';
     const okResult: Result<string, string> = Ok(value);
@@ -30,6 +32,11 @@ describe('Result', () => {
     });
 
     test('unwrapErr should throw', () => {
+      expect(() => okResult.unwrapErr()).toThrow();
+    });
+
+    test('unwrapErr may throw with custom message', () => {
+      expect(() => okResult.unwrapErr(errorMsg)).toThrow(errorMsg);
       expect(() => okResult.unwrapErr()).toThrow();
     });
 
@@ -91,6 +98,11 @@ describe('Result', () => {
     });
 
     test('unwrap should throw', () => {
+      expect(() => errResult.unwrap()).toThrow();
+    });
+
+    test('unwrap may throw with custom message', () => {
+      expect(() => errResult.unwrap(errorMsg)).toThrow(errorMsg);
       expect(() => errResult.unwrap()).toThrow();
     });
 

--- a/src/result/result.ts
+++ b/src/result/result.ts
@@ -102,7 +102,7 @@ export interface Result<T extends NonUndefined, E extends NonUndefined> {
    * console.log(Err("error").unwrap()); // throws Error
    * ```
    */
-  unwrap(): T | never;
+  unwrap(msg?: string): T | never;
 
   /**
    * Unwraps a Result, yielding the contained error value if Err, otherwise throws an error.
@@ -117,7 +117,7 @@ export interface Result<T extends NonUndefined, E extends NonUndefined> {
    * console.log(Ok("value").unwrapErr()); // throws Error
    * ```
    */
-  unwrapErr(): E | never;
+  unwrapErr(msg?: string): E | never;
 
   /**
    * Returns the contained success value if Ok, otherwise returns the provided default value.
@@ -288,12 +288,16 @@ class OkImpl<T extends NonUndefined, E extends NonUndefined> implements OkResult
     return Ok(this.val);
   }
 
-  unwrap(): T {
+  unwrap(_msg?: string): T {
     return this.val;
   }
 
-  unwrapErr(): never {
-    throw new ReferenceError('Cannot unwrap Err value of Result.Ok');
+  unwrapErr(msg?: string): never {
+    if (msg) {
+      throw new Error(msg);
+    } else {
+      throw new ReferenceError('Cannot unwrap Err value of Result.Ok');
+    }
   }
 
   unwrapOr(_optb: T): T {
@@ -347,11 +351,15 @@ class ErrImpl<T extends NonUndefined, E extends NonUndefined> implements ErrResu
     return fn(this.val);
   }
 
-  unwrap(): never {
-    throw new ReferenceError('Cannot unwrap Ok value of Result.Err');
+  unwrap(msg?: string): never {
+    if (msg) {
+      throw new Error(msg);
+    } else {
+      throw new ReferenceError('Cannot unwrap Ok value of Result.Err');
+    }
   }
 
-  unwrapErr(): E {
+  unwrapErr(_msg?: string): E {
     return this.val;
   }
 


### PR DESCRIPTION
Reference: <https://doc.rust-lang.org/std/result/enum.Result.html#method.expect>

Implemented by adding an optional message string parameter for the respective unwraps.