### PR TITLE
allow match statements to return `void`

### DIFF
--- a/src/either/either.ts
+++ b/src/either/either.ts
@@ -179,7 +179,7 @@ export interface Either<L extends NonUndefined, R extends NonUndefined> {
    * console.log(result); // "Error: error"
    * ```
    */
-  match<U extends NonUndefined>(fn: Match<L, R, U>): U;
+  match<U extends NonUndefined | void>(fn: Match<L, R, U>): U;
 
   /**
    * Maps an Either by applying a function to its Left value, leaving Right untouched.
@@ -316,7 +316,7 @@ class LeftImpl<L extends NonUndefined, R extends NonUndefined> implements Either
     return other;
   }
 
-  match<U extends NonUndefined>(matchObject: Match<L, R, U>): U {
+  match<U extends NonUndefined | void>(matchObject: Match<L, R, U>): U {
     return matchObject.left(this.val);
   }
 
@@ -383,7 +383,7 @@ class RightImpl<L extends NonUndefined, R extends NonUndefined> implements Eithe
     return this.val;
   }
 
-  match<U extends NonUndefined>(matchObject: Match<L, R, U>): U {
+  match<U extends NonUndefined | void>(matchObject: Match<L, R, U>): U {
     return matchObject.right(this.val);
   }
 

--- a/src/option/option.ts
+++ b/src/option/option.ts
@@ -86,7 +86,7 @@ export interface Option<T extends NonUndefined> {
    * console.log(matchResultNone); // Outputs: "There is no value."
    * ```
    */
-  match<U extends NonUndefined>(fn: Match<T, U>): U;
+  match<U extends NonUndefined | void>(fn: Match<T, U>): U;
 
   /**
    * Applies a function to the contained value (if any), or returns a default if None.

--- a/src/result/result.ts
+++ b/src/result/result.ts
@@ -156,7 +156,7 @@ export interface Result<T extends NonUndefined, E extends NonUndefined> {
    * // error === "Error: failure"
    * ```
    */
-  match<U extends NonUndefined>(fn: Match<T, E, U>): U;
+  match<U extends NonUndefined | void>(fn: Match<T, E, U>): U;
 
   /**
    * Maps a Result<Ok, Err> to Result<U, Err> by applying a function to a contained Ok value,
@@ -276,7 +276,7 @@ class OkImpl<T extends NonUndefined, E extends NonUndefined> implements OkResult
     return None as NoneOption<E>;
   }
 
-  match<U extends NonUndefined>(matchObject: Match<T, E, U>): U {
+  match<U extends NonUndefined | void>(matchObject: Match<T, E, U>): U {
     return matchObject.ok(this.val);
   }
 
@@ -335,7 +335,7 @@ class ErrImpl<T extends NonUndefined, E extends NonUndefined> implements ErrResu
     return Some(this.val);
   }
 
-  match<U extends NonUndefined>(matchObject: Match<T, E, U>): U {
+  match<U extends NonUndefined | void>(matchObject: Match<T, E, U>): U {
     return matchObject.err(this.val);
   }
 


### PR DESCRIPTION
This would previously not compile:

```js
option.match({
    some: (value) => {
        console.log("")
    },
    none: () => {
        console.log("");
    },
});
```

